### PR TITLE
🧫 Ajout d'un linter Python

### DIFF
--- a/.github/workflows/python-linter-pr.yaml
+++ b/.github/workflows/python-linter-pr.yaml
@@ -9,18 +9,17 @@
 # de la licence CeCILL difusée sur le site "http://www.cecill.info".
 
 
-name: Lint
+name: Python Linter for Pull Requests
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - master
-      - beta
-  pull_request:
-    branches:
-      - master
-      - beta
+  pull_request_target:
+
+# On restreint les permissions d'Action pour éviter que de potentielles PR malicieuses
+# aient un trop grand accès à notre repo, mais normalement ici il n'y a pas de problème 
+# puisqu'on n'exécute pas le code de la PR
+permissions:
+  checks: write
+  contents: write
 
 jobs:
   run-linters:
@@ -37,14 +36,16 @@ jobs:
           python-version: '3.10' 
 
       - name: Install Python dependencies
-        run: pip install black flake8 pylint autopep8
+        run: pip install black pylint
 
       - name: Run linters
         uses: wearerequired/lint-action@121b69fdf77b22fa2bbb8d081b455bd31d563197
         with:
-          black: true
+          # Sur les Pull Requests, Black est désactivé car Github Actions n'as pas les
+          # droits d'écriture sur les forks (il corrigera donc les fautes au moment du merge)
+          black: false
           pylint: true
-          auto_fix: true
-          git_name: "GuniLint"
-          git_email: "linter@gunivers.net"
-          commit_message: "🌟 style: fix code style issues with ${linter}"
+          pylint_args: "--disable=C,R,I"
+
+          # Idem, pas de droits d'écriture, pas d'auto-fix
+          auto_fix: false

--- a/.github/workflows/python-linter-push.yaml
+++ b/.github/workflows/python-linter-push.yaml
@@ -1,0 +1,47 @@
+# © Aeris1One, aeris@aeris-one.fr (2022) 
+#
+# Ce fichier représente un programme informatique servant à vérifier que le
+# code de ce dépôt est fonctionnel et conforme à la PEP-8.
+#
+# Ce programme est régi par la licence CeCILL soumise au droit français et
+# respectant les principes de diffusion des logiciels libres. Vous pouvez
+# utiliser, modifier et/ou redistribuer ce programme sous les conditions
+# de la licence CeCILL difusée sur le site "http://www.cecill.info".
+
+
+name: Python Linter for Push
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - beta
+
+jobs:
+  run-linters:
+    name: Run linters
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
+
+      - name: Install Python dependencies
+        run: pip install black pylint
+
+      - name: Run linters
+        uses: wearerequired/lint-action@121b69fdf77b22fa2bbb8d081b455bd31d563197
+        with:
+          black: true
+          pylint: true
+          pylint_args: "--disable=C,R,I"
+          auto_fix: true
+          git_name: "GuniLint"
+          git_email: "linter@gunivers.net"
+          commit_message: "🌟 style: fix code style issues with ${linter}"

--- a/.github/workflows/python-linter.yaml
+++ b/.github/workflows/python-linter.yaml
@@ -1,0 +1,22 @@
+# © Aeris1One, aeris@aeris-one.fr (2022) 
+#
+# Ce fichier représente un programme informatique servant à vérifier que le
+# code de ce dépôt est fonctionnel et conforme à la PEP-8.
+#
+# Ce programme est régi par la licence CeCILL soumise au droit français et
+# respectant les principes de diffusion des logiciels libres. Vous pouvez
+# utiliser, modifier et/ou redistribuer ce programme sous les conditions
+# de la licence CeCILL difusée sur le site "http://www.cecill.info".
+
+
+name: python-linter
+
+on: [push]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: rahul-deepsource/pyaction@master

--- a/.github/workflows/python-linter.yaml
+++ b/.github/workflows/python-linter.yaml
@@ -9,14 +9,42 @@
 # de la licence CeCILL difusée sur le site "http://www.cecill.info".
 
 
-name: python-linter
+name: Lint
 
-on: [push]
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - beta
+  pull_request:
+    branches:
+      - master
+      - beta
 
 jobs:
-  lint:
+  run-linters:
+    name: Run linters
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: rahul-deepsource/pyaction@master
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
+
+      - name: Install Python dependencies
+        run: pip install black flake8 pylint autopep8
+
+      - name: Run linters
+        uses: wearerequired/lint-action@121b69fdf77b22fa2bbb8d081b455bd31d563197
+        with:
+          black: true
+          pylint: true
+          auto_fix: true
+          git_name: "GuniLint"
+          git_email: "linter@gunivers.net"
+          commit_message: "🌟 style: fix code style issues with ${linter}"


### PR DESCRIPTION
Cette PR est soumise à discussion quant-aux réglages.
Dans l'état actuel, le linter vérifie non seulement que le code Python est correct (pas de fonction appelée non définie par exemple), indique les morceaux de code inutiles (une fonction importée mais non utilisée) mais ausi vas reformater selon la PEP-8 pour que le code soit lisible par les personnes habituées à travailler en PEP-8.

Je pense que ça permettrai d'avoir un code bien plus uniforme, là où je sais que chacun à ses petites habitudes. Cependant il y avait déjà eu le débat sur Discord à propos de certains formatages, pas forcément autorisés par la PEP-8 qui semble pour certains plus clairs que d'autres.

Que faisons-nous ?