### PR TITLE
🧱 deps: use discord.py 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ feedparser>=6.0
 python-twitter>=3.5
 async_timeout>=3.0
 argparse
-git+https://github.com/Rapptz/discord.py@v2.0.0
+discord.py==2.0


### PR DESCRIPTION
Use discord.py 2.0 release from PyPi instead of building from source