### PR TITLE
🧱 feat(config): Réécriture de la configuration

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -47,7 +47,7 @@ def append_dict(dict1: dict, dict2: dict):
         else:
             dict1[key] = value
 
-T = TypeVar("T", )
+T = TypeVar("T")
 
 class ConfigurationField(Generic[T]):
     def __init__(
@@ -159,15 +159,38 @@ class Configuration():
         self.fields[field.name] = field
 
 if __name__ == "__main__":
-    # géré par le cœur
-    config = Configuration(is_child=False)
-    config.load("test.yaml")
+    # géré par le cœur, qui charge les fichiers comme il veut
+    # le développeur de plugin doit ne pas avoir à toucher à ces initialisations
+    config1 = Configuration(is_child=False)
+    config1.load("test.yaml")
 
-    class DiscordConfiguration(Configuration):
-        token = ConfigurationField(str)
+    # si le développeur a vraiment la flemme mais une flemme paradoxale, il
+    # peut accéder à la configuration comme ceci
+    print(config1["ban"]["friendly_ban"])
+
+    # cette partie est le minimum syndicale pour le développeur
+    ban_config_1 = Configuration(namespace="ban")
+    config1.add_configuration_child(ban_config_1)
+
+    # à partir de là le développeur peut accéder à la configuration comme suit
+    print(ban_config_1['friendly_ban'])
+    # on est d'accord que c'est plus propre que ce qui est affiché plus haut
+
+    # nouvelle exemple
+
+    config2 = Configuration(is_child=False)
+    config2.load("test.yaml")
+
+    # le développeur de plugin peut aussi ajouter les champs en tant que variable
+    class BanConfiguration(Configuration):
+        friendly_ban = ConfigurationField(bool) # on pourra définir le type, avoir une conversion des données, mettre une valeur par défaut etc à terme
     
-    test = DiscordConfiguration("discord")
-    config.add_configuration_child(test)
+    # les mêmes étapes que plus haut (le *minimum syndical*)
+    ban_config_2 = BanConfiguration("ban")
+    config2.add_configuration_child(ban_config_2)
 
-    print(test.token)
+    # et pouf ça fait des chocapic
+    print(ban_config_2.friendly_ban)
+    # encore plus propre que plus haut non ?
+    # et ça supporte le typage avec par ex vscode ! (si tu spécifie un type)
 

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+from typing import Generic, TypeVar, Any
+
 import json
 import os
 from shutil import copyfile
 
+import yaml
 
 def get_config(path: str, isBotConfig: bool):
     if not os.path.isfile(path + ".json"):
@@ -20,3 +24,150 @@ def get_config(path: str, isBotConfig: bool):
             )
             return None
     return conf
+
+def append_dict(dict1: dict, dict2: dict):
+    """Append dict2 to dict1, overwriting keys in dict1 if they exist in dict2.
+    Lists are extended, not overwritten.
+    If the type of a key in dict2 is different from the type of the same key in
+    dict1, the key in dict1 is overwritten.
+    """
+    for key, value in dict2.items():
+        if isinstance(value, dict): # append recursively dict to dict
+            node = dict1.setdefault(key, {})
+            if isinstance(node, dict):
+                append_dict(node, value)
+            else: # if the key in the origin dict is not the same type, overwrite it
+                dict1[key] = value
+        elif isinstance(value, list):
+            node = dict1.setdefault(key, [])
+            if isinstance(node, list):
+                node.extend(value)
+            else: # if the key in the origin dict is not the same type, overwrite it
+                dict1[key] = value
+        else:
+            dict1[key] = value
+
+T = TypeVar("T", )
+
+class ConfigurationField(Generic[T]):
+    def __init__(
+        self,
+        type: type[T] = Any,
+        default: T | None = None,
+        key: str | None = None,
+    ):
+        self.type = type
+        self.default = None
+        self.key = key
+
+    def __get__(self, instance: Configuration, owner=None) -> T:
+        if instance is None:
+            return self
+        
+        value = instance.raw_configuration.get(self.key, self.default)
+        
+        return value
+
+class Configuration():
+    __fields = {}
+
+    parent: Configuration | None = None
+
+    def __init_subclass__(cls) -> None:
+        for attr_key in dir(cls):
+            attr = getattr(cls, attr_key)
+            if isinstance(attr, ConfigurationField):
+                if attr.key is None:
+                    attr.key = attr_key
+                cls.__fields[attr_key] = attr
+
+    def __init__(
+        self,
+        namespace: str | None = None,
+        is_child: bool = True,
+    ):
+        self.is_child = is_child
+
+        if not self.is_child:
+            if namespace is not None:
+                raise ValueError("The root configuration must not have a namespace.")
+            self._raw_configuration = {}
+        else:
+            self._raw_configuration = None
+        
+        self.namespace = namespace
+
+        self.fields = {}
+        
+        self.fields.update(self.__fields)
+
+        self.child_configurations = {}
+    
+    @property
+    def raw_configuration(self):
+        if self.is_child:
+            return self.parent.raw_configuration.get(self.namespace, {})
+        else:
+            return self._raw_configuration
+    
+    def load(self, file: os.PathLike):
+        """Append the configuration from a file to the current loaded
+        configuration.
+        
+        This function manages overwrites using the `append_dict` function.
+        """
+
+        if self.is_child:
+            raise NotImplementedError("Child configurations cannot load files.")
+
+        with open(file, 'r') as config_file:
+            raw_config = yaml.load(config_file, Loader=yaml.FullLoader)
+
+        append_dict(self._raw_configuration, raw_config)
+    
+    def __getitem__(self, index):
+        if index in self.child_configurations:
+            return self.child_configurations[index]
+        elif index in self.fields:
+            return self.fields[index].__get__(self)
+        elif index in self.raw_configuration:
+            return self.raw_configuration[index]
+        else:
+            raise KeyError(f"Configuration field '{index}' does not exist.")
+    
+    def __setitem__(self, index, value):
+        raise NotImplementedError("Configuration fields are read only.")
+    
+    def __delitem__(self, index, value):
+        raise NotImplementedError("Configuration fields are read only.")
+    
+    def add_configuration_child(self, configuration: Configuration):
+        if configuration.namespace is None:
+            raise ValueError("The child configuration must have a namespace.")
+        
+        if configuration.namespace in self.child_configurations:
+            raise ValueError(f"The namespace '{configuration.namespace}' is already used.")
+        
+        configuration.parent = self
+        self.child_configurations[configuration.namespace] = configuration
+    
+    def add_configuration_field(self, field: ConfigurationField):
+        if field.name in self.fields:
+            raise ValueError(f"The field '{field.name}' is already used.")
+        
+        field.parent = self
+        self.fields[field.name] = field
+
+if __name__ == "__main__":
+    # géré par le cœur
+    config = Configuration(is_child=False)
+    config.load("test.yaml")
+
+    class DiscordConfiguration(Configuration):
+        token = ConfigurationField(str)
+    
+    test = DiscordConfiguration("discord")
+    config.add_configuration_child(test)
+
+    print(test.token)
+

--- a/bot/test.yaml
+++ b/bot/test.yaml
@@ -1,5 +1,2 @@
-discord:
-  token: "LOLTHISISATOKEN"
-
-discord2:
-  token: "LOLTHISISATOKEN V2"
+ban:
+  friendly_ban: on

--- a/bot/test.yaml
+++ b/bot/test.yaml
@@ -1,0 +1,5 @@
+discord:
+  token: "LOLTHISISATOKEN"
+
+discord2:
+  token: "LOLTHISISATOKEN V2"


### PR DESCRIPTION
Cette PR a pour but d'écrire un nouveau système de configuration pour être à la fois plus simple pour débuter et plus puissant avec une utilisation avancée.

Le fichier affecté pour le moment par la réécriture est indépendant du reste du projet.
Je commencerais à modifier les plugins pour fonctionner avec ce système quand il sera mature.

Pour voir l'état actuel de l'écriture du nouveau système de configuration, vous pouvez aller voir l'exemple contenu à la fin du fichier `bot/config.py`.

Je met ici ce qu'il est possible de faire avec le système mais je ne garantie pas qu'il sera à jour :

```py
# géré par le cœur, qui charge les fichiers comme il veut
# le développeur de plugin doit ne pas avoir à toucher à ces initialisations
config1 = Configuration(is_child=False)
config1.load("test.yaml")

# si le développeur a vraiment la flemme mais une flemme paradoxale, il
# peut accéder à la configuration comme ceci
print(config1["ban"]["friendly_ban"])

# cette partie est le minimum syndicale pour le développeur
ban_config_1 = Configuration(namespace="ban")
config1.add_configuration_child(ban_config_1)

# à partir de là le développeur peut accéder à la configuration comme suit
print(ban_config_1['friendly_ban'])
# on est d'accord que c'est plus propre que ce qui est affiché plus haut

# nouvelle exemple

config2 = Configuration(is_child=False)
config2.load("test.yaml")

# le développeur de plugin peut aussi ajouter les champs en tant que variable
class BanConfiguration(Configuration):
    friendly_ban = ConfigurationField(bool) # on pourra définir le type, avoir une conversion des données, mettre une valeur par défaut etc à terme

# les mêmes étapes que plus haut (le *minimum syndical*)
ban_config_2 = BanConfiguration("ban")
config2.add_configuration_child(ban_config_2)

# et pouf ça fait des chocapic
print(ban_config_2.friendly_ban)
# encore plus propre que plus haut non ?
# et ça supporte le typage avec par ex vscode ! (si tu spécifie un type)
```