### PR TITLE
Fix rolelink command name inconsistency

### DIFF
--- a/plugins/roleLink/langs/en.yml
+++ b/plugins/roleLink/langs/en.yml
@@ -5,4 +5,4 @@ en:
     dep-notfound: Cannot find a role-link with this identifier. You can get the identifier of a link with the `%{p}rolelink list` command
     infinite: "Oops, it seems that this dependency can lead to an infinite loop with at least the following dependency: \"%{dep}\"\nIf you're sure you want to continue, enter 'yes' in the next %{t} seconds..."
     list: "List of your roles-links:"
-    no-dep: "You do not have any dependencies configured at the moment.\nUse the `%{p}rolelink create` command to add more dependencies"
+    no-dep: "You do not have any dependencies configured at the moment.\nUse the `%{p}rolelink add` command to add more dependencies"

--- a/plugins/roleLink/langs/fr.yml
+++ b/plugins/roleLink/langs/fr.yml
@@ -5,4 +5,4 @@ fr:
     dep-notfound: Impossible de trouver une rôle-liaison avec cet identifiant.\nVous pouvez obtenir l'identifiant d'une liaison avec la commande `%{p}rolelink list`
     infinite: "Oups, il semble que cette dépendance puisse entraîner une boucle infinie avec au moins la dépendance suivante : \"%{dep}\"\nSi vous êtes sûr de vouloir continuer, entrez 'oui' dans les %{t} prochaines secondes"
     list: "Liste de vos rôles-liaisons :"
-    no-dep: "Vous n'avez aucune dépendance de configurée pour le moment.\nUtilisez la commande `%{p}rolelink create` pour en ajouter"
+    no-dep: "Vous n'avez aucune dépendance de configurée pour le moment.\nUtilisez la commande `%{p}rolelink add` pour en ajouter"


### PR DESCRIPTION
Cette PR résout un problème de consistance dans les message d'aide du plugin roleLink.

Closes #16 