### PR TITLE
🗣Fix for translation configuration

### DIFF
--- a/bot/utils/languages.py
+++ b/bot/utils/languages.py
@@ -35,16 +35,16 @@ class Languages(commands.Cog):
         lang = self.languages[0]
         if isinstance(ctx, commands.Context):
             if ctx.guild:
-                lang = self.languages[await self.get_lang(ctx.guild.id)]
+                lang = await self.get_lang(ctx.guild.id, use_str=True)
         elif isinstance(ctx, discord.Guild):
-            lang = self.languages[await self.get_lang(ctx.id)]
+            lang = await self.get_lang(ctx.id, use_str=True)
         elif isinstance(ctx, discord.abc.GuildChannel):
-            lang = self.languages[await self.get_lang(ctx.guild.id)]
+            lang = await self.get_lang(ctx.guild.id, use_str=True)
         elif isinstance(ctx, str) and ctx in self.languages:
             lang = ctx
         elif isinstance(ctx, int):  # guild ID
             if self.bot.get_guild(ctx):  # if valid guild
-                lang = self.languages[await self.get_lang(ctx)]
+                lang = await self.get_lang(ctx, use_str=True)
             else:
                 lang = self.languages[0]
         return i18n.t(key, locale=lang, **kwargs)
@@ -53,7 +53,9 @@ class Languages(commands.Cog):
         if guildID is None:
             as_int = 0
         else:
-            as_int = self.languages.index(self.bot.server_configs[guildID]["language"])
+            as_int = self.languages.index(
+                self.bot.server_configs[guildID]["language"]
+            )
         if use_str:
             return self.languages[as_int]
         return as_int

--- a/bot/utils/sconfig.py
+++ b/bot/utils/sconfig.py
@@ -311,8 +311,9 @@ class Sconfig(commands.Cog):
                 await self.bot._(ctx.guild.id, "sconfig.invalid-language", p=ctx.prefix)
             )
         else:  # correct case
-            selected = cog.languages.index(lang)
-            await ctx.send(await self.edit_config(ctx.guild.id, "language", selected))
+            await ctx.send(
+                await self.edit_config(ctx.guild.id, "language", lang)
+            ) # lang should be a string
 
     # --------------------------------------------------
     # Hypesquad


### PR DESCRIPTION
La configuration de language était cassée car par défaut l'information est retournée sous forme de chaîne (`en` par exemple), alors qu'elle est stockée sous forme d'entier par la commande config.

Pour régler ce problème, la fonction `!config language` a été modifiée pour stocker la langue en utilisant une chaîne de caractère.