### PR TITLE
🕳 Fix webhook issues when deleted

### DIFF
--- a/plugins/wormhole/credits.md
+++ b/plugins/wormhole/credits.md
@@ -2,7 +2,7 @@ Copyright © Fantomitechno 2021
 Copyright © Leirof 2021 - 2022
 Copyright © ZRunner 2021
 Copyright © Theaustudio 2021
-Copyright © ascpial 2021
+Copyright © ascpial 2021 - 2023
 Copyright © Aeris One 2022
 
 Ce programme est régi par la licence CeCILL soumise au droit français et


### PR DESCRIPTION
Avant cette PR, quand le webhook d'un wormhole est supprimé, le programme ne s'adapte pas et n'en créé pas de nouveau.

Cette PR résout ce problème et ajoute un message d'erreur dans la console dans le cas où le message n'a pas pu être édité.

Closes #96.