### PR TITLE
🧹 Remove console spam when stopping the bot

### DIFF
--- a/bot/utils/sconfig.py
+++ b/bot/utils/sconfig.py
@@ -82,7 +82,7 @@ class Sconfig(commands.Cog):
                 if "command" in opt:
                     try:
                         self.bot.get_command("config " + opt["command"]).enabled = False
-                    except AttributeError:
+                    except (AttributeError, TypeError): # if opt["command"] is None
                         # if the command doesn't exist
                         pass
             del self.sorted_options[cog]

--- a/plugins/help/help.py
+++ b/plugins/help/help.py
@@ -618,6 +618,6 @@ async def setup(bot:Gunibot=None, plugin_config:dict=None):
         global config
         config.update(plugin_config)
         
-def teardown(bot: Gunibot):
+async def teardown(bot: Gunibot):
     bot.help_command = commands.DefaultHelpCommand()
-    bot.remove_cog("HelpCog")
+    await bot.remove_cog("HelpCog")

--- a/utils.py
+++ b/utils.py
@@ -200,7 +200,7 @@ class Gunibot(commands.bot.AutoShardedBot):
         """Get a cog icon"""
         return self.cog_icons.get(cog_name.lower())
 
-    def remove_cog(self, cog: str):
+    async def remove_cog(self, cog: str):
         """Removes a cog from the bot.
 
         All registered commands and event listeners that the
@@ -213,7 +213,7 @@ class Gunibot(commands.bot.AutoShardedBot):
         name: :class:`str`
             The name of the cog to remove.
         """
-        super().remove_cog(cog)
+        await super().remove_cog(cog)
         for module in self.cogs.values():
             if not isinstance(cog, type(module)):
                 if hasattr(module, "on_anycog_unload"):


### PR DESCRIPTION
Depuis une mise à jour de `discord.py`, les fonctions `bot.remove_cog` et `teardown` sont devenues asynchrones.

C'est pour cette raison que la console recevais un certain nombre d'erreurs liées au déchargement des plugins.

L'utilisation de fonctions asynchrones quand nécessaire a réglé ce problème.