### PR TITLE
❓Fix long subcommand list in help

### DIFF
--- a/plugins/help/help.py
+++ b/plugins/help/help.py
@@ -330,7 +330,8 @@ class Help(commands.HelpCommand):
             result += "**"
             if len(result) > 1024:
                 result = result[:1023] + "…"
-        result += "\n```"
+        else:
+            result += "\n```"
 
         return result if len(result) > 0 else None
 


### PR DESCRIPTION
Cette PR retire les accents graves affichés à la fin du message d'aide pour les commandes ayant beaucoup de sous-commanbes comme par exemple la commande de configuration.