### PR TITLE
📶 Initial slash commands support

### DIFF
--- a/bot/utils/errors.py
+++ b/bot/utils/errors.py
@@ -56,30 +56,36 @@ class Errors(commands.Cog):
             await ctx.send(
                 await self.bot._(
                     ctx.channel, "errors.cooldown", c=round(error.retry_after, 2)
-                )
+                ),
+                ephemeral=True,
             )
             return
         elif isinstance(error, CheckException):
             return await ctx.send(
-                await self.bot._(ctx.channel, "errors.custom_checks." + error.id)
+                await self.bot._(ctx.channel, "errors.custom_checks." + error.id),
+                ephemeral=True,
             )
         elif isinstance(error, (commands.BadArgument, commands.BadUnionArgument)):
             raw_error = str(error)
             if raw_error == "Unknown argument":
                 return await ctx.send(
-                    await self.bot._(ctx.channel, "errors.unknown-arg")
+                    await self.bot._(ctx.channel, "errors.unknown-arg"),
+                    ephemeral=True,
                 )
             elif raw_error == "Unknown dependency action type":
                 return await ctx.send(
-                    await self.bot._(ctx.channel, "errors.invalid-dependency")
+                    await self.bot._(ctx.channel, "errors.invalid-dependency"),
+                    ephemeral=True,
                 )
             elif raw_error == "Unknown dependency trigger type":
                 return await ctx.send(
-                    await self.bot._(ctx.channel, "errors.invalid-trigger")
+                    await self.bot._(ctx.channel, "errors.invalid-trigger"),
+                    ephemeral=True,
                 )
             elif raw_error == "Unknown permission type":
                 return await ctx.send(
-                    await self.bot._(ctx.channel, "errors.invalid-permission")
+                    await self.bot._(ctx.channel, "errors.invalid-permission"),
+                    ephemeral=True,
                 )
             # Could not convert "limit" into int. OR Converting to "int" failed
             # for parameter "number".
@@ -99,7 +105,8 @@ class Errors(commands.Cog):
                         "errors.unknown-arg",
                         p=r.group("arg"),
                         t=r.group("type"),
-                    )
+                    ),
+                    ephemeral=True,
                 )
             # zzz is not a recognised boolean option
             r = re.search(
@@ -113,37 +120,43 @@ class Errors(commands.Cog):
                         "errors.invalid-type",
                         p=r.group("arg"),
                         t=r.group("type"),
-                    )
+                    ),
+                    ephemeral=True,
                 )
             # Member "Z_runner" not found
             r = re.search(r"Member \"([^\"]+)\" not found", raw_error)
             if r is not None:
                 return await ctx.send(
-                    await self.bot._(ctx.channel, "errors.unknown-member", m=r.group(1))
+                    await self.bot._(ctx.channel, "errors.unknown-member", m=r.group(1)),
+                    ephemeral=True,
                 )
             # User "Z_runner" not found
             r = re.search(r"User \"([^\"]+)\" not found", raw_error)
             if r is not None:
                 return await ctx.send(
-                    await self.bot._(ctx.channel, "errors.unknown-user", u=r.group(1))
+                    await self.bot._(ctx.channel, "errors.unknown-user", u=r.group(1)),
+                    ephemeral=True,
                 )
             # Role "Admin" not found
             r = re.search(r"Role \"([^\"]+)\" not found", raw_error)
             if r is not None:
                 return await ctx.send(
-                    await self.bot._(ctx.channel, "errors.unknown-role", r=r.group(1))
+                    await self.bot._(ctx.channel, "errors.unknown-role", r=r.group(1)),
+                    ephemeral=True,
                 )
             # Emoji ":shock:" not found
             r = re.search(r"Emoji \"([^\"]+)\" not found", raw_error)
             if r is not None:
                 return await ctx.send(
-                    await self.bot._(ctx.channel, "errors.unknown-emoji", e=r.group(1))
+                    await self.bot._(ctx.channel, "errors.unknown-emoji", e=r.group(1)),
+                    ephemeral=True,
                 )
             # Colour "blue" is invalid
             r = re.search(r"Colour \"([^\"]+)\" is invalid", raw_error)
             if r is not None:
                 return await ctx.send(
-                    await self.bot._(ctx.channel, "errors.invalid-color", c=r.group(1))
+                    await self.bot._(ctx.channel, "errors.invalid-color", c=r.group(1)),
+                    ephemeral=True,
                 )
             # Channel "twitter" not found.
             r = re.search(r"Channel \"([^\"]+)\" not found", raw_error)
@@ -151,7 +164,8 @@ class Errors(commands.Cog):
                 return await ctx.send(
                     await self.bot._(
                         ctx.channel, "errors.unknown-channel", c=r.group(1)
-                    )
+                    ),
+                    ephemeral=True,
                 )
             # Message "1243" not found.
             r = re.search(r"Message \"([^\"]+)\" not found", raw_error)
@@ -159,18 +173,21 @@ class Errors(commands.Cog):
                 return await ctx.send(
                     await self.bot._(
                         ctx.channel, "errors.unknown-message", m=r.group(1)
-                    )
+                    ),
+                    ephemeral=True
                 )
             # Group "twitter" not found.
             r = re.search(r"Group \"([^\"]+)\" not found", raw_error)
             if r is not None:
                 return await ctx.send(
-                    await self.bot._(ctx.channel, "errors.unknown-group", g=r.group(1))
+                    await self.bot._(ctx.channel, "errors.unknown-group", g=r.group(1)),
+                    ephemeral=True,
                 )
             # Too many text channels
             if raw_error == "Too many text channels":
                 return await ctx.send(
-                    await self.bot._(ctx.channel, "errors.too-many-text-channels")
+                    await self.bot._(ctx.channel, "errors.too-many-text-channels"),
+                    ephemeral=True,
                 )
             # Invalid duration: 2d
             r = re.search(r"Invalid duration: ([^\" ]+)", raw_error)
@@ -178,48 +195,55 @@ class Errors(commands.Cog):
                 return await ctx.send(
                     await self.bot._(
                         ctx.channel, "errors.invalid-duration", d=r.group(1)
-                    )
+                    ),
+                    ephemeral=True,
                 )
             # Invalid invite: nope
             r = re.search(r"Invalid invite: (\S+)", raw_error)
             if r is not None:
                 return await ctx.send(
-                    await self.bot._(ctx.channel, "errors.invalid-invite")
+                    await self.bot._(ctx.channel, "errors.invalid-invite"),
+                    ephemeral=True,
                 )
             # Invalid guild: test
             r = re.search(r"Invalid guild: (\S+)", raw_error)
             if r is not None:
                 return await ctx.send(
-                    await self.bot._(ctx.channel, "errors.unknown-server")
+                    await self.bot._(ctx.channel, "errors.unknown-server"),
+                    ephemeral=True,
                 )
             # Invalid url: nou
             r = re.search(r"Invalid url: (\S+)", raw_error)
             if r is not None:
                 return await ctx.send(
-                    await self.bot._(ctx.channel, "errors.invalid-url")
+                    await self.bot._(ctx.channel, "errors.invalid-url"),
+                    ephemeral=True,
                 )
             # Invalid emoji: lmao
             r = re.search(r"Invalid emoji: (\S+)", raw_error)
             if r is not None:
                 return await ctx.send(
-                    await self.bot._(ctx.channel, "errors.invalid-emoji")
+                    await self.bot._(ctx.channel, "errors.invalid-emoji"),
+                    ephemeral=True,
                 )
             print("errors -", error)
         elif isinstance(error, commands.MissingRequiredArgument):
             await ctx.send(
-                await self.bot._(ctx.channel, "errors.missing-arg", a=error.param.name)
+                await self.bot._(ctx.channel, "errors.missing-arg", a=error.param.name),
+                ephemeral=True,
             )
             return
         elif isinstance(error, commands.DisabledCommand):
             await ctx.send(
-                await self.bot._(ctx.channel, "errors.disabled-cmd", c=ctx.invoked_with)
+                await self.bot._(ctx.channel, "errors.disabled-cmd", c=ctx.invoked_with),
+                ephemeral=True,
             )
             return
         elif isinstance(error, commands.errors.NoPrivateMessage):
-            await ctx.send(await self.bot._(ctx.channel, "errors.disabled-dm"))
+            await ctx.send(await self.bot._(ctx.channel, "errors.disabled-dm"), ephemeral=True)
             return
         else:
-            await ctx.send(await self.bot._(ctx.channel, "errors.error-unknown"))
+            await ctx.send(await self.bot._(ctx.channel, "errors.error-unknown"), ephemeral=True)
         # All other Errors not returned come here... And we can just print the
         # default TraceBack.
         self.bot.log.warning(

--- a/plugins/messageManager/langs/en.yml
+++ b/plugins/messageManager/langs/en.yml
@@ -16,5 +16,6 @@ en:
         footer: "Messages moved by %{user}"
         missing-perm: "Unable to do this :confused: Please check that I have permission to Read channel, Read message history, Manage messages in this channel, and Read channel, Manage webhooks in the targeted chat"
         no-msg: No message found
+        completed: "Moving %{counter} messages completed"
       permission: "You cannot move messages. Make sure you have the permissions to see the messages you want to move, and manage the messages in both channels."
       no-channel: "Unable to find the channel. If it is a channel on another server, please indicate its ID"

--- a/plugins/messageManager/langs/en.yml
+++ b/plugins/messageManager/langs/en.yml
@@ -5,6 +5,8 @@
 
 en:
   message_manager:
+      imitate:
+        success: "Message sent !"
       move:
         confirm: "%{user}, your message was moved in %{channel}"
         footer: "Message moved by %{user}"

--- a/plugins/messageManager/langs/fr.yml
+++ b/plugins/messageManager/langs/fr.yml
@@ -5,6 +5,8 @@
 
 fr:
   message_manager:
+      imitate:
+        success: "Message envoyé !"
       move:
         confirm: "%{user}, votre message a été déplacé dans %{channel}"
         footer: "Message déplacé par %{user}"

--- a/plugins/messageManager/langs/fr.yml
+++ b/plugins/messageManager/langs/fr.yml
@@ -16,5 +16,6 @@ fr:
         footer: "Messages déplacés par %{user}"
         missing-perm: "Impossible de faire cela :confused: Vérifiez que je possède la permission de Lire le salon, Lire l'historique des messages, Gérer les messages dans ce salon, et Lire le salon, Gérer les webhooks dans le salon ciblé"
         no-msg: Aucun message trouvé
+        completed: "Déplacement de %{counter} messages terminé"
       permission: "Vous ne pouvez pas déplacer les messages. Assurez vous d'avoir les permissions pour voir les messages que vous souhtaitez déplacer, et gérer les messages dans les deux salons."
       no-channel: "Impossible de trouver le salon. S'il s'agit d'un salon sur un autre serveur, merci d'indiquer son identifiant"

--- a/plugins/messageManager/messageManager.py
+++ b/plugins/messageManager/messageManager.py
@@ -6,6 +6,7 @@ de la licence CeCILL diffusée sur le site "http://www.cecill.info".
 """
 
 import discord
+from discord import app_commands
 from discord.ext import commands
 from utils import Gunibot
 from typing import Union
@@ -49,11 +50,19 @@ class MessageManager(commands.Cog):
     # Command /imitate #
     # -------------------#
 
-    @commands.command(name="imitate")
+    @commands.hybrid_command(name="imitate", description="Say something with someone else's appearance")
+    @app_commands.describe(
+        member="The member you want to imitate",
+        text="The text you want to say"
+    )
     @commands.guild_only()
     @commands.has_permissions(manage_messages=True, manage_nicknames=True)
     async def imitate(
-            self, ctx: commands.Context, member: discord.Member = None, *, text=None
+            self,
+            ctx: commands.Context,
+            member: discord.Member = None,
+            *,
+            text=None
     ):
         """Say something with someone else's appearance"""
 
@@ -64,13 +73,24 @@ class MessageManager(commands.Cog):
 
             # Deletes the original message as well as the webhook
             await webhook.delete()
-            await ctx.message.delete()
+            if not ctx.interaction:
+                await ctx.message.delete()
+            else:
+                await ctx.send(
+                    await self.bot._(ctx.guild.id, "message_manager.imitate.success"),
+                    ephemeral=True,
+                    delete_after=3
+                )
 
     # ----------------#
     # Command /move #
     # ----------------#
 
     @commands.hybrid_command(names="move", aliases=["mv"])
+    @app_commands.describe(
+        msg="The message you want to move",
+        channel="The channel where you want to move the message"
+    )
     @commands.guild_only()
     @commands.has_permissions(
         manage_messages=True,
@@ -165,6 +185,11 @@ class MessageManager(commands.Cog):
     # -------------------#
 
     @commands.hybrid_command(names="moveall", aliases=["mva"])
+    @app_commands.describe(
+        msg1="The first message of the conversation you want to move",
+        msg2="The last message of the conversation you want to move",
+        channel="The channel where you want to move the messages"
+    )
     @commands.guild_only()
     @commands.has_permissions(
         manage_messages=True,

--- a/start.py
+++ b/start.py
@@ -116,6 +116,15 @@ def main():
             logs.info("Connected on " + str(len(client.guilds)) + " servers")
         loaded, failed = await load(client, global_systems, plugins)
         logs.info(f"{loaded} plugins loaded, {failed} plugins failed")
+
+        # Syncing the commands
+        logs.info("♻️ Syncing app commands...")
+        try:
+            await client.tree.sync()
+        except discord.DiscordException as e:
+            logs.error(f"⚠️ Error while syncing app commands: {e}")
+        else:
+            logs.info("✅ App commands synced")
         print(
             "--------------------------------------------------------------------------------"
         )


### PR DESCRIPTION
Pour le moment, seul le plugin messageManager a été converti aux Slash commands mais le coeur et la gestion d'erreurs sont désormais prêts pour le passage aux hybrid_commands.