### PR TITLE
🐛 fix(voice): fix voice channel random name

### DIFF
--- a/plugins/voice/config.yaml
+++ b/plugins/voice/config.yaml
@@ -1,0 +1,1 @@
+randommer_api_key: ''

--- a/plugins/voice/voice.py
+++ b/plugins/voice/voice.py
@@ -230,7 +230,7 @@ class VoiceChannels(commands.Cog):
 
         # If we don't have any names in cache, we get some new ones
         randommer_api_key = self.config.get("randommer_api_key")
-        if source != "asterix" and randommer_api_key is not None:
+        if source != "asterix" and randommer_api_key != '':
             headers = {"X-Api-Key": randommer_api_key}
             async with aiohttp.ClientSession() as session:
                 async with session.get(

--- a/plugins/voice/voice.py
+++ b/plugins/voice/voice.py
@@ -227,7 +227,7 @@ class VoiceChannels(commands.Cog):
 
         # Otherwise, we get some new ones
         # Using local file for asterix names
-        if source == "asterix":
+        if True or source == "asterix":
             with open(
                 "plugins/voice/rsrc/asterix_names.txt", "r", encoding="utf-8"
             ) as file:
@@ -235,16 +235,18 @@ class VoiceChannels(commands.Cog):
                 random.shuffle(self.names[source])
             return self.names[source].pop()
 
+        # TODO : This part is fully broken, should be rewritten.
+        #  In the meantime, we use Asterix names for everything
         # Using randommer.io for random names
-        else:
-            headers = {"X-Api-Key": self.bot.config["random_api_token"]}
-            async with aiohttp.ClientSession() as session:
-                async with session.get(
-                    "https://randommer.io/api/Name?nameType=surname&quantity=20",
-                    headers=headers,
-                ) as resp:
-                    self.names[source] = await resp.json()
-                return self.names[source].pop()
+        #else:
+            #headers = {"X-Api-Key": self.bot.config["randommer_api_key"]}
+            #async with aiohttp.ClientSession() as session:
+            #    async with session.get(
+            #        "https://randommer.io/api/Name?nameType=surname&quantity=20",
+            #        headers=headers,
+            #    ) as resp:
+            #        self.names[source] = await resp.json()
+            #    return self.names[source].pop()
 
     @commands.command(name="voice-clean")
     @commands.guild_only()

--- a/plugins/voice/voice.py
+++ b/plugins/voice/voice.py
@@ -208,12 +208,6 @@ class VoiceChannels(commands.Cog):
         # add to database
         self.db_add_channel(new_channel)
 
-        channel = self.bot.get_channel(379308111774875650)
-        await channel.send("Hello World!")
-        liste = self.bot.db_query("SELECT guild, channel FROM voices_chats", ())
-        for row in liste:
-            await channel.send(row)
-
     async def delete_channel(self, channel: discord.VoiceChannel):
         """Delete an unusued channel if no one is in"""
         if (


### PR DESCRIPTION
Petite correction de bug sur le système de noms de salons.

Tout est corrigé, si aucune clé pour l'API de randommer n'est spécifié dans la config, les noms d'Astérix sont utilisés en fallback (au lieu du vieux "None" d'avant)