### PR TITLE
🐛Various fixes for wormhole

### DIFF
--- a/plugins/wormhole/wormhole.py
+++ b/plugins/wormhole/wormhole.py
@@ -595,12 +595,12 @@ class Wormholes(commands.Cog):
             await ctx.send(await self.bot._(ctx.guild.id, "wormhole.error.not-linked"))
             return
         query = "DELETE FROM wormhole_channel WHERE channelID = ? AND name = ?"
+        self.bot.db_query(query, (ctx.channel.id, wh_channel[0]))
         async with ClientSession() as session:
             webhook = discord.Webhook.partial(
                 wh_channel[4], wh_channel[5], session=session
             )
             await webhook.delete()
-        self.bot.db_query(query, (wh_channel[0], ctx.channel.id))
         await ctx.send(
             await self.bot._(ctx.guild.id, "wormhole.success.channel-unlinked")
         )

--- a/plugins/wormhole/wormhole.py
+++ b/plugins/wormhole/wormhole.py
@@ -408,7 +408,7 @@ class Wormholes(commands.Cog):
                                 colour=0x2F3136,  # 2F3136
                             )
                         else:
-                            content = content.replace("\n", " ")
+                            content = reply.content.replace("\n", " ")
                             if len(content) > 80:
                                 content = content[:80] + "..."
                             embed_reply = discord.Embed(


### PR DESCRIPTION
Cette PR résout différent problèmes avec le plugin wormhole.

Tout d'abord, cette PR résout #154 (et #149), et permet à nouveau aux réponses de fonctionner.

Ensuite, cette PR résout #136 et ajoute l'embed de réponse à la liste des embeds au moment d'éditer un message.

Cette PR résout aussi un problème lié à la vérification faite sur le message avant la modification, qui empêchait un bot de propager la modification d'un message à travers le wormhole (comme par exemple avec la commande `!stats`).

Enfin, cette PR résout #153 et répare `!wormhole unlink`.