### PR TITLE
🐛 Fix normal emoji for levelup

### DIFF
--- a/plugins/xp/xp.py
+++ b/plugins/xp/xp.py
@@ -114,7 +114,7 @@ class XP(commands.Cog):
 
     @commands.command(name="reaction_emoji")
     async def config_levelup_reaction_emoji(
-        self, ctx: MyContext, emote: discord.Emoji = None
+        self, ctx: MyContext, emote: Union[discord.Emoji, str] = None
     ):
         """Set the emoji wich one the bot will react to message when levelup"""
         # check if emoji is valid


### PR DESCRIPTION
Cette PR résout un problème empêchant d'utiliser un emoji par défaut de discord pour la réaction de levelup.